### PR TITLE
Allow to change the device used in postprocessing

### DIFF
--- a/src/yue/infer_postprocess.py
+++ b/src/yue/infer_postprocess.py
@@ -59,7 +59,7 @@ def post_process(
             print(e)
 
     # vocoder to upsample audios
-    vocal_decoder, inst_decoder = build_codec_model(config_path, vocal_decoder_path, inst_decoder_path)
+    vocal_decoder, inst_decoder = build_codec_model(config_path, vocal_decoder_path, inst_decoder_path, device)
     vocoder_output_dir = os.path.join(output_dir, "vocoder")
     vocoder_stems_dir = os.path.join(vocoder_output_dir, "stems")
     vocoder_mix_dir = os.path.join(vocoder_output_dir, "mix")


### PR DESCRIPTION
Add a device parameter to vocoder and pass the torch device from infer_postprocess.py to it.

This addresses a part of #19 as one can now use `CUDA_VISIBLE_DEVICES=""` to run the postprocessing on CPU avoiding an OOM error when one has enough GPU RAM.

I also added a `--device` parameter to the vocoder.py `main` function as the `build_codec_model` now needs a device parameter. I did not test vocoder.py standalone as I only know how to use the infer scripts.
One might also want to add a --device parameter (or three for the different stages) to the infer scripts.

Tell me if you want changes before merging.

This might also be interesting for @a43992899 to add to the original repo. I only tested in with this repo, though.